### PR TITLE
Allow for multiclass classification

### DIFF
--- a/catboost-rs/src/model.rs
+++ b/catboost-rs/src/model.rs
@@ -70,7 +70,7 @@ impl Model {
             .map(|x| x.as_ptr())
             .collect::<Vec<_>>();
 
-        let mut prediction = vec![0.0; float_features.len()];
+        let mut prediction = vec![0.0; float_features.len() * self.get_dimensions_count()];
         CatBoostError::check_return_value(unsafe {
             catboost_sys::CalcModelPredictionWithHashedCatFeatures(
                 self.handle,


### PR DESCRIPTION
Hi,
I noticed that this binding works only with binary classification. I added small change to allow for multiclass classification.
Ideally it should put vec! inside vec!, but it requires changes in a couple of places as well.